### PR TITLE
update to work with kernel 6.15

### DIFF
--- a/v4l2loopback/v4l2loopback-dc.c
+++ b/v4l2loopback/v4l2loopback-dc.c
@@ -1511,8 +1511,8 @@ vidioc_querybuf     (struct file *file,
 static void
 buffer_written(struct v4l2_loopback_device *dev, struct v4l2l_buffer *buf)
 {
-  del_timer_sync(&dev->sustain_timer);
-  del_timer_sync(&dev->timeout_timer);
+  timer_delete_sync(&dev->sustain_timer);
+  timer_delete_sync(&dev->timeout_timer);
   spin_lock_bh(&dev->lock);
 
   dev->bufpos2index[dev->write_position % dev->used_buffers] = buf->buffer.index;
@@ -1933,8 +1933,8 @@ v4l2_loopback_close  (struct file *file)
 
   atomic_dec(&dev->open_count);
   if (dev->open_count.counter == 0) {
-    del_timer_sync(&dev->sustain_timer);
-    del_timer_sync(&dev->timeout_timer);
+    timer_delete_sync(&dev->sustain_timer);
+    timer_delete_sync(&dev->timeout_timer);
   }
   try_free_buffers(dev);
   kfree(opener);

--- a/v4l2loopback/v4l2loopback-dc.c
+++ b/v4l2loopback/v4l2loopback-dc.c
@@ -1266,6 +1266,45 @@ vidioc_s_ctrl(struct file *file, void *fh,
   return 0;
 }
 
+static int
+vidioc_g_ext_ctrls(struct file *file, void *fh,
+                   struct v4l2_ext_controls *ctls)
+{
+  struct v4l2_control ctrl;
+  int i, ret = 0;
+
+  for (i = 0; i < ctls->count; i++) {
+    ctrl.id = ctls->controls[i].id;
+    ctrl.value = ctls->controls[i].value;
+    ret = vidioc_g_ctrl(file, fh, &ctrl);
+    ctls->controls[i].value = ctrl.value;
+    if (ret) {
+      ctls->error_idx = i;
+      break;
+    }
+  }
+  return ret;
+}
+
+static int
+vidioc_s_ext_ctrls(struct file *file, void *fh,
+                   struct v4l2_ext_controls *ctls)
+{
+  struct v4l2_control ctrl;
+  int i, ret = 0;
+
+  for (i = 0; i < ctls->count; i++) {
+    ctrl.id = ctls->controls[i].id;
+    ctrl.value = ctls->controls[i].value;
+    ret = vidioc_s_ctrl(file, fh, &ctrl);
+    ctls->controls[i].value = ctrl.value;
+    if (ret) {
+      ctls->error_idx = i;
+      break;
+    }
+  }
+  return ret;
+}
 
 /* returns set of device outputs, in our case there is only one
  * called on VIDIOC_ENUMOUTPUT
@@ -2346,8 +2385,8 @@ static const struct v4l2_ioctl_ops v4l2_loopback_ioctl_ops = {
 #endif
 
   .vidioc_query_ext_ctrl    = &vidioc_query_ext_ctrl,
-  .vidioc_g_ctrl            = &vidioc_g_ctrl,
-  .vidioc_s_ctrl            = &vidioc_s_ctrl,
+  .vidioc_s_ext_ctrls       = &vidioc_s_ext_ctrls,
+  .vidioc_g_ext_ctrls       = &vidioc_g_ext_ctrls,
 
   .vidioc_enum_output       = &vidioc_enum_output,
   .vidioc_g_output          = &vidioc_g_output,

--- a/v4l2loopback/v4l2loopback-dc.c
+++ b/v4l2loopback/v4l2loopback-dc.c
@@ -1145,11 +1145,11 @@ vidioc_querystd     (struct file *file,
 
 
 /* get ctrls info
- * called on VIDIOC_QUERYCTRL
+ * called on VIDIOC_QUERY_EXT_CTRL
  */
 static int
-vidioc_queryctrl(struct file *file, void *fh,
-                 struct v4l2_queryctrl *q)
+vidioc_query_ext_ctrl(struct file *file, void *fh,
+                 struct v4l2_query_ext_ctrl *q)
 {
   switch (q->id) {
   case CID_KEEP_FORMAT:
@@ -1170,22 +1170,23 @@ vidioc_queryctrl(struct file *file, void *fh,
     return -EINVAL;
   }
 
+  q->default_value = 0;
+  q->nr_of_dims = 0;
+  q->elems = 1;
+  q->elem_size = 4;
+
   switch (q->id) {
   case CID_KEEP_FORMAT:
     strcpy(q->name, "keep_format");
-    q->default_value = 0;
     break;
   case CID_SUSTAIN_FRAMERATE:
     strcpy(q->name, "sustain_framerate");
-    q->default_value = 0;
     break;
   case CID_TIMEOUT:
     strcpy(q->name, "timeout");
-    q->default_value = 0;
     break;
   case CID_TIMEOUT_IMAGE_IO:
     strcpy(q->name, "timeout_image_io");
-    q->default_value = 0;
     break;
   default:
     BUG();
@@ -2344,7 +2345,7 @@ static const struct v4l2_ioctl_ops v4l2_loopback_ioctl_ops = {
   .vidioc_enum_frameintervals = &vidioc_enum_frameintervals,
 #endif
 
-  .vidioc_queryctrl         = &vidioc_queryctrl,
+  .vidioc_query_ext_ctrl    = &vidioc_query_ext_ctrl,
   .vidioc_g_ctrl            = &vidioc_g_ctrl,
   .vidioc_s_ctrl            = &vidioc_s_ctrl,
 


### PR DESCRIPTION
kernel 6.15 has changed the v4l2_ioctl_ops interface.
This pull requests 
- Remove vidioc_g/s callback
- Replace queryctrl with query_ext_ctrl
- rename timer_delete_sync() to del_timer_sync()